### PR TITLE
fix: ブログ記事のレンダリングエラーを修正

### DIFF
--- a/src/content/blog/2026-04-29-ai-and-cybersecurity-defense.md
+++ b/src/content/blog/2026-04-29-ai-and-cybersecurity-defense.md
@@ -65,7 +65,7 @@ https://simonwillison.net/2025/Oct/22/openai-ciso-on-atlas/
 
 https://security.googleblog.com/2025/06/mitigating-prompt-injection-attacks.html
 
-https://openai.com/index/prompt-injections/
+[Prompt Injections](https://openai.com/index/prompt-injections/)
 
 ### 2. 従来から存在した脅威の変化
 

--- a/src/content/blog/2026-04-29-ai-and-cybersecurity-defense.md
+++ b/src/content/blog/2026-04-29-ai-and-cybersecurity-defense.md
@@ -65,7 +65,7 @@ https://simonwillison.net/2025/Oct/22/openai-ciso-on-atlas/
 
 https://security.googleblog.com/2025/06/mitigating-prompt-injection-attacks.html
 
-[Prompt Injections](https://openai.com/index/prompt-injections/)
+[OpenAI: Understanding prompt injections: a frontier security challenge](https://openai.com/index/prompt-injections/)
 
 ### 2. 従来から存在した脅威の変化
 

--- a/src/content/podcasts/replayfm-84-e3iku9b.json
+++ b/src/content/podcasts/replayfm-84-e3iku9b.json
@@ -1,0 +1,10 @@
+{
+  "kind": "podcast",
+  "mediaTitle": "Replay.fm",
+  "title": "#84 重要なソフトウェアって具体的にどれー！の回",
+  "date": "2026-04-29T11:53:45.000Z",
+  "link": "https://podcasters.spotify.com/pod/show/replyfm/episodes/84-e3iku9b",
+  "ogpImageUrl": "https://d3t3ozftmdmh3i.cloudfront.net/staging/podcast_uploaded_nologo/40380813/40380813-1744331787433-19ee7616fe0f.jpg",
+  "uniqueTitle": "replayfm",
+  "uniqueItemKey": "84-e3iku9b"
+}


### PR DESCRIPTION
## 概要

最新のブログ記事(`2026-04-29-ai-and-cybersecurity-defense.md`)のレンダリングが失敗し、記事本文が空になる問題を修正。

## 原因

`@sota1235/remark-link-bookmark` プラグインが記事内のスタンドアロンURL(`https://openai.com/index/prompt-injections/`)のOGP情報を取得する際に、OpenAI側が403 Forbiddenを返す。プラグインの `fetchOgpInfo` 関数が `ogs()` の例外をキャッチできず、`Promise.all` 経由でエラーが伝播し、記事全体のmarkdownレンダリングがクラッシュしていた。

## 対応

該当URLをスタンドアロン形式（リンクカード）から通常のインラインリンク `[Prompt Injections](...)` に変更し、プラグインの処理対象から除外。

## 補足

プラグイン側のエラーハンドリング(`ogs()` 呼び出しのtry-catch)も改善すべきだが、別途対応とする。

## テストプラン

- [x] `pnpm exec astro build` が成功すること
- [x] ビルド後の記事HTMLに本文が含まれていること（25,388文字）
- [ ] デプロイ後に https://sota1235.com/blog/2026-04-29-ai-and-cybersecurity-defense/ で記事が表示されること