### PR TITLE
add: Cloudflareデプロイ用の設定ファイルとセキュリティヘッダー

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,3 +1,6 @@
 name = "sota1235-com"
 compatibility_date = "2026-05-01"
-pages_build_output_dir = "./dist"
+
+[assets]
+directory = "./dist"
+not_found_handling = "404-page"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,6 @@
 name = "sota1235-com"
 compatibility_date = "2026-05-01"
+workers_dev = true
 
 [assets]
 directory = "./dist"


### PR DESCRIPTION
## Summary

- Cloudflare（Workers + Static Assets）にデプロイするための `wrangler.toml` を追加
- 基本的なセキュリティヘッダーを `public/_headers` に追加

## 変更内容

### `wrangler.toml`
当初は Pages 用の `pages_build_output_dir` で書いていたが、Cloudflare ダッシュボードでの新規プロジェクト作成導線が Workers に統一されており、ビルド時に `wrangler deploy on a Pages project` の Warning が出ていたため、Workers Static Assets 形式（`[assets]` セクション）に変更。

```toml
name = "sota1235-com"
compatibility_date = "2026-05-01"

[assets]
directory = "./dist"
not_found_handling = "404-page"
```

`not_found_handling = "404-page"` で Astro が出力する `dist/404.html` を 404 応答として配信する。

### `public/_headers`
CSP は Partytown / GA との兼ね合いで調整が必要なため一旦見送り、副作用の少ない基本セットのみ追加。

- `Strict-Transport-Security`: 1 年・includeSubDomains（preload は外す）
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy`: 不要なブラウザ API を全拒否

## Test plan

- [ ] Cloudflare ダッシュボードのビルドログで `wrangler deploy on a Pages project` Warning が消えていること
- [ ] デプロイ後、存在しないパスで Astro の 404 ページが表示されること
- [ ] レスポンスヘッダーに `strict-transport-security` 等の追加ヘッダーが含まれていること
- [ ] 既存ページ（/, /blog, /biography, /media）が問題なく配信されること

https://claude.ai/code/session_01CcqGLDXeZuMxEceZJYfKxi

---
_Generated by [Claude Code](https://claude.ai/code/session_01CcqGLDXeZuMxEceZJYfKxi)_