### PR TITLE
add: 10X Product Blog の sota1235 著記事 (2026-04) を companyBlog に追加

### DIFF
--- a/src/content/companyBlog/10x-2026-04-01-github-app-private-key-on-kms.json
+++ b/src/content/companyBlog/10x-2026-04-01-github-app-private-key-on-kms.json
@@ -1,0 +1,6 @@
+{
+  "title": "GitHub Appの秘密鍵をGitHub Secretsから追い出す",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/01/163814",
+  "pubDate": "2026-04-01"
+}

--- a/src/content/companyBlog/10x-2026-04-07-validate-github-member-with-conftest.json
+++ b/src/content/companyBlog/10x-2026-04-07-validate-github-member-with-conftest.json
@@ -1,0 +1,6 @@
+{
+  "title": "GitHubへのメンバー追加をConftestでバリデーションする",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/07/170704",
+  "pubDate": "2026-04-07"
+}

--- a/src/content/companyBlog/10x-2026-04-15-access-github-api-without-pat.json
+++ b/src/content/companyBlog/10x-2026-04-15-access-github-api-without-pat.json
@@ -1,0 +1,6 @@
+{
+  "title": "PATも秘密鍵も管理せずにGoogle CloudからGitHub APIにアクセスする",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/15/163802",
+  "pubDate": "2026-04-15"
+}


### PR DESCRIPTION
## Summary

[10X Product Blog の sota1235 著者ページ](https://product.10x.co.jp/archive/author/sota1235) を確認し、`src/content/companyBlog` 未登録の sota1235 著記事 3 件を追加しました。

| 公開日 | タイトル | URL |
| --- | --- | --- |
| 2026-04-01 | GitHub Appの秘密鍵をGitHub Secretsから追い出す | https://product.10x.co.jp/entry/2026/04/01/163814 |
| 2026-04-07 | GitHubへのメンバー追加をConftestでバリデーションする | https://product.10x.co.jp/entry/2026/04/07/170704 |
| 2026-04-15 | PATも秘密鍵も管理せずにGoogle CloudからGitHub APIにアクセスする | https://product.10x.co.jp/entry/2026/04/15/163802 |

## Test plan

- [ ] `pnpm run build` で companyBlog コレクションのスキーマ検証が通ること
- [ ] `/media` ページに 3 件の記事が `pubDate` 降順で正しく表示されること


---
_Generated by [Claude Code](https://claude.ai/code/session_01GAgAKzjMN4VCUQyRbGQqGM)_