### PR TITLE
add: 10X Product Blogの記事を追加（2026年4月）

### DIFF
--- a/src/content/companyBlog/10x-2026-04-01-163814.json
+++ b/src/content/companyBlog/10x-2026-04-01-163814.json
@@ -1,0 +1,6 @@
+{
+  "title": "GitHub Appの秘密鍵をGitHub Secretsから追い出す",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/01/163814",
+  "pubDate": "2026-04-01"
+}

--- a/src/content/companyBlog/10x-2026-04-07-170704.json
+++ b/src/content/companyBlog/10x-2026-04-07-170704.json
@@ -1,0 +1,6 @@
+{
+  "title": "GitHubへのメンバー追加をConftestでバリデーションする",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/07/170704",
+  "pubDate": "2026-04-07"
+}

--- a/src/content/companyBlog/10x-2026-04-15-163802.json
+++ b/src/content/companyBlog/10x-2026-04-15-163802.json
@@ -1,0 +1,6 @@
+{
+  "title": "PATも秘密鍵も管理せずにGoogle CloudからGitHub APIにアクセスする",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/15/163802",
+  "pubDate": "2026-04-15"
+}


### PR DESCRIPTION
## Summary

[10X Product Blog の sota1235 著者ページ](https://product.10x.co.jp/archive/author/sota1235) を確認し、`src/content/companyBlog` 未追加の sota1235 著者記事 3 本を追加します。

| pubDate | タイトル | URL |
| --- | --- | --- |
| 2026-04-01 | GitHub Appの秘密鍵をGitHub Secretsから追い出す | https://product.10x.co.jp/entry/2026/04/01/163814 |
| 2026-04-07 | GitHubへのメンバー追加をConftestでバリデーションする | https://product.10x.co.jp/entry/2026/04/07/170704 |
| 2026-04-15 | PATも秘密鍵も管理せずにGoogle CloudからGitHub APIにアクセスする | https://product.10x.co.jp/entry/2026/04/15/163802 |

## Notes

- `product.10x.co.jp` はサンドボックスの egress 許可リストに含まれていなかったため、ページ HTML の直接取得はできず、Web 検索結果から sota1235 著者の記事として抽出しています。誤って別著者の記事が含まれていた場合は本 PR を閉じるか該当ファイルだけ削除してください。
- ファイル命名は直近の `10x-2026-03-06-155210.json` と同じく `10x-YYYY-MM-DD-HHMMSS.json` 形式に揃えています。

## Test plan

- [ ] `pnpm run astro check` が通ること
- [ ] `pnpm run build` 後、`/media`（または該当一覧ページ）で 3 件が表示されること

https://claude.ai/code/session_01V1tU6bg527R8wnMn4byChM

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1tU6bg527R8wnMn4byChM)_