### PR TITLE
add: 10X Product Blogのsota1235著記事3件を追加（2026年4月分）

### DIFF
--- a/src/content/companyBlog/10x-2026-04-01-163814.json
+++ b/src/content/companyBlog/10x-2026-04-01-163814.json
@@ -1,0 +1,6 @@
+{
+  "title": "GitHub Appの秘密鍵をGitHub Secretsから追い出す",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/01/163814",
+  "pubDate": "2026-04-01"
+}

--- a/src/content/companyBlog/10x-2026-04-07-170704.json
+++ b/src/content/companyBlog/10x-2026-04-07-170704.json
@@ -1,0 +1,6 @@
+{
+  "title": "GitHubへのメンバー追加をConftestでバリデーションする",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/07/170704",
+  "pubDate": "2026-04-07"
+}

--- a/src/content/companyBlog/10x-2026-04-15-163802.json
+++ b/src/content/companyBlog/10x-2026-04-15-163802.json
@@ -1,0 +1,6 @@
+{
+  "title": "PATも秘密鍵も管理せずにGoogle CloudからGitHub APIにアクセスする",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/15/163802",
+  "pubDate": "2026-04-15"
+}


### PR DESCRIPTION
## Summary

[product.10x.co.jp/archive/author/sota1235](https://product.10x.co.jp/archive/author/sota1235) で未登録だった sota1235 著の 2026 年 4 月の記事 3 件を `src/content/companyBlog` に追加します。

## Added articles

- [GitHub Appの秘密鍵をGitHub Secretsから追い出す](https://product.10x.co.jp/entry/2026/04/01/163814) (2026-04-01)
- [GitHubへのメンバー追加をConftestでバリデーションする](https://product.10x.co.jp/entry/2026/04/07/170704) (2026-04-07)
- [PATも秘密鍵も管理せずにGoogle CloudからGitHub APIにアクセスする](https://product.10x.co.jp/entry/2026/04/15/163802) (2026-04-15)

## Test plan

- [ ] CI (Prettier / astro check / pa11y / Lighthouse) がパスすること
- [ ] ローカルで `pnpm dev` を実行し、トップページや `/media` 等に記事が表示されることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01WC5hpyvDwpoByK6oxdYk3g)_