### PR TITLE
10X.fmとZero Topicのpodcastエントリを追加

### DIFF
--- a/src/content/podcasts/10x_tech_talk8--Podcast-wsota1235-e3esmdj.json
+++ b/src/content/podcasts/10x_tech_talk8--Podcast-wsota1235-e3esmdj.json
@@ -2,7 +2,7 @@
   "kind": "podcast",
   "mediaTitle": "10X.fm Tech Talk",
   "title": "8. セキュリティチームの最近のお仕事やPodcast運営について w/sota1235",
-  "date": "2022-02-12T12:00:00.000Z",
+  "date": "2026-02-12T12:00:00.000Z",
   "link": "https://creators.spotify.com/pod/profile/10x66/episodes/8--Podcast-wsota1235-e3esmdj",
   "ogpImageUrl": "https://d3t3ozftmdmh3i.cloudfront.net/staging/podcast_uploaded_nologo400/38627796/38627796-1757643580878-e430209ecb6c1.jpg",
   "uniqueTitle": "10xfm_tech_talk",

--- a/src/content/podcasts/10xfm-27-3010X-SRE-e1jm7k1.json
+++ b/src/content/podcasts/10xfm-27-3010X-SRE-e1jm7k1.json
@@ -1,0 +1,10 @@
+{
+  "kind": "podcast",
+  "mediaTitle": "10X.fm",
+  "title": "#27 30分でわかる10X SREチームの全貌",
+  "date": "2022-06-09T12:00:00.000Z",
+  "link": "https://podcasts.apple.com/us/podcast/27-30%E5%88%86%E3%81%A7%E3%82%8F%E3%81%8B%E3%82%8B10x-sre%E3%83%81%E3%83%BC%E3%83%A0%E3%81%AE%E5%85%A8%E8%B2%8C/id1562020110?i=1000565902771",
+  "ogpImageUrl": "https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_nologo400/14265390/14265390-1617780503303-d5a91709b248f.jpg",
+  "uniqueTitle": "10xfm",
+  "uniqueItemKey": "27-3010X-SRE-e1jm7k1"
+}

--- a/src/content/podcasts/zerotopic-184-What-is-the-experience-behind-the-10X-Values--with-sota1235-e17l696.json
+++ b/src/content/podcasts/zerotopic-184-What-is-the-experience-behind-the-10X-Values--with-sota1235-e17l696.json
@@ -1,0 +1,10 @@
+{
+  "kind": "podcast",
+  "mediaTitle": "Zero Topic - ゼロトピック -",
+  "title": "#184 What is the experience behind the 10X Values? (with @sota1235)",
+  "date": "2021-09-21T12:00:00.000Z",
+  "link": "https://creators.spotify.com/pod/profile/yamotty/episodes/184-What-is-the-experience-behind-the-10X-Values--with-sota1235-e17l696",
+  "ogpImageUrl": "https://d3t3ozftmdmh3i.cloudfront.net/production/podcast_uploaded_episode400/3606512/3606512-1632200001659-5fd3c542f6a94.jpg",
+  "uniqueTitle": "zerotopic",
+  "uniqueItemKey": "184-What-is-the-experience-behind-the-10X-Values--with-sota1235-e17l696"
+}


### PR DESCRIPTION
## 概要

過去出演したpodcastエピソードを `src/content/podcasts/` に追加します。

- **10X.fm #27** [30分でわかる10X SREチームの全貌](https://podcasts.apple.com/us/podcast/27-30%E5%88%86%E3%81%A7%E3%82%8F%E3%81%8B%E3%82%8B10x-sre%E3%83%81%E3%83%BC%E3%83%A0%E3%81%AE%E5%85%A8%E8%B2%8C/id1562020110?i=1000565902771) (2022-06-09)
- **Zero Topic #184** [What is the experience behind the 10X Values? (with @sota1235)](https://creators.spotify.com/pod/profile/yamotty/episodes/184-What-is-the-experience-behind-the-10X-Values--with-sota1235-e17l696) (2021-09-21)

また、既存の `10x_tech_talk8--Podcast-wsota1235-e3esmdj` ファイルが拡張子なしでcontent collectionから読み込まれていなかった問題を併せて修正し、`.json` 拡張子を付与しています。

## テストプラン

- [ ] \`pnpm dev\` でローカル起動し、`/media` ページに追加した2件のエントリが表示されること
- [ ] OGP画像、タイトル、日付が正しく表示されること
- [ ] 各エントリのリンクが正しい配信先に遷移すること
- [ ] \`pnpm run build\` が成功すること