### PR TITLE
feat: 10X Product Blogの新着記事を追加

### DIFF
--- a/src/content/companyBlog/10x-2026-04-01-evict-github-app-private-key.json
+++ b/src/content/companyBlog/10x-2026-04-01-evict-github-app-private-key.json
@@ -1,0 +1,6 @@
+{
+  "title": "GitHub Appの秘密鍵をGitHub Secretsから追い出す",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/01/163814",
+  "pubDate": "2026-04-01"
+}

--- a/src/content/companyBlog/10x-2026-04-07-validate-github-membership-with-conftest.json
+++ b/src/content/companyBlog/10x-2026-04-07-validate-github-membership-with-conftest.json
@@ -1,0 +1,6 @@
+{
+  "title": "GitHubへのメンバー追加をConftestでバリデーションする",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/07/170704",
+  "pubDate": "2026-04-07"
+}

--- a/src/content/companyBlog/10x-2026-04-15-access-github-api-from-google-cloud.json
+++ b/src/content/companyBlog/10x-2026-04-15-access-github-api-from-google-cloud.json
@@ -1,0 +1,6 @@
+{
+  "title": "PATも秘密鍵も管理せずにGoogle CloudからGitHub APIにアクセスする",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/15/163802",
+  "pubDate": "2026-04-15"
+}


### PR DESCRIPTION
## Summary

[product.10x.co.jp/archive/author/sota1235](https://product.10x.co.jp/archive/author/sota1235) を確認し、`src/content/companyBlog/` に未追加だった sota1235 著者の記事 3 本を追加しました。

| 公開日 | タイトル | URL |
| --- | --- | --- |
| 2026-04-01 | GitHub Appの秘密鍵をGitHub Secretsから追い出す | https://product.10x.co.jp/entry/2026/04/01/163814 |
| 2026-04-07 | GitHubへのメンバー追加をConftestでバリデーションする | https://product.10x.co.jp/entry/2026/04/07/170704 |
| 2026-04-15 | PATも秘密鍵も管理せずにGoogle CloudからGitHub APIにアクセスする | https://product.10x.co.jp/entry/2026/04/15/163802 |

## Notes

- 著者ページ (`/archive/author/sota1235`) は WebFetch で 403 が返り直接の取得ができなかったため、Web 検索の複数結果を突き合わせて sota1235 が著者であることを確認しています。
- 既存ファイル ([10x-2026-03-06-155210.json](https://github.com/sota1235/sota1235.github.io/blob/main/src/content/companyBlog/10x-2026-03-06-155210.json) 等) と同じ JSON スキーマに従っています。

## Test plan

- [ ] `pnpm run build` が通る（content collection のバリデーション含む）
- [ ] 各記事の `link` を開いて該当記事が表示されること
- [ ] サイト上の「会社のブログ」一覧に 3 件が表示されること

---
_Generated by [Claude Code](https://claude.ai/code/session_01UM2PxHvk8iSDid3wYsEW74)_