### PR TITLE
10Xブログ記事を追加: GitHubへのメンバー追加をConftestでバリデーションする

### DIFF
--- a/src/content/companyBlog/10x-2026-04-07-validate-github-members-with-conftest.json
+++ b/src/content/companyBlog/10x-2026-04-07-validate-github-members-with-conftest.json
@@ -1,0 +1,6 @@
+{
+  "title": "GitHubへのメンバー追加をConftestでバリデーションする",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/07/170704",
+  "pubDate": "2026-04-07"
+}


### PR DESCRIPTION
## 概要

[product.10x.co.jp の sota1235 author アーカイブ](https://product.10x.co.jp/archive/author/sota1235) を確認し、未登録の新規記事を `src/content/companyBlog` に追加しました。

### 追加した記事（author: sota1235）

- [GitHubへのメンバー追加をConftestでバリデーションする](https://product.10x.co.jp/entry/2026/04/07/170704) (2026-04-07)

## 要確認事項

本セッションの実行環境では `product.10x.co.jp` がネットワークの allowlist 外のため直接アクセスできず、WebSearch 経由で記事と著者を確認しました。以下の April 2026 記事も新規候補として見つかりましたが、author の扱いについて確認をお願いします。

- [PATも秘密鍵も管理せずにGoogle CloudからGitHub APIにアクセスする](https://product.10x.co.jp/entry/2026/04/15/163802) (2026-04-15) — 本文冒頭が「セキュリティチームの yagihashi です」で始まるため **author は sota1235 ではない** と判断し、**追加していません**。
- [GitHub Appの秘密鍵をGitHub Secretsから追い出す](https://product.10x.co.jp/entry/2026/04/01/163814) (2026-04-01) — author を断定できませんでした。Octo STS 関連シリーズ（yagihashi 著）と同テーマのため一旦 **追加を見送っています**。sota1235 の記事であれば追加します。

その他、`2026/01/09 conftestによる自動レビュー`、`2026/01/31 Octo STS...`（yagihashi 著）も既存リポジトリに未登録ですが、author が sota1235 でない/前回メンテ時点で対象外と判断したため追加していません。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vitni43T4iEbNqVgJnSQJf)_