### PR TITLE
10X Product Blog の sota1235 著者記事を4件追加

### DIFF
--- a/src/content/companyBlog/10x-2026-01-09-154331.json
+++ b/src/content/companyBlog/10x-2026-01-09-154331.json
@@ -1,0 +1,6 @@
+{
+  "title": "conftestによる自動レビュー",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/01/09/154331",
+  "pubDate": "2026-01-09"
+}

--- a/src/content/companyBlog/10x-2026-04-01-163814.json
+++ b/src/content/companyBlog/10x-2026-04-01-163814.json
@@ -1,0 +1,6 @@
+{
+  "title": "GitHub Appの秘密鍵をGitHub Secretsから追い出す",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/01/163814",
+  "pubDate": "2026-04-01"
+}

--- a/src/content/companyBlog/10x-2026-04-07-170704.json
+++ b/src/content/companyBlog/10x-2026-04-07-170704.json
@@ -1,0 +1,6 @@
+{
+  "title": "GitHubへのメンバー追加をConftestでバリデーションする",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/07/170704",
+  "pubDate": "2026-04-07"
+}

--- a/src/content/companyBlog/10x-2026-04-15-163802.json
+++ b/src/content/companyBlog/10x-2026-04-15-163802.json
@@ -1,0 +1,6 @@
+{
+  "title": "PATも秘密鍵も管理せずにGoogle CloudからGitHub APIにアクセスする",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/15/163802",
+  "pubDate": "2026-04-15"
+}


### PR DESCRIPTION
## 概要

[10X Product Blog の sota1235 著者ページ](https://product.10x.co.jp/archive/author/sota1235) を確認し、`src/content/companyBlog` に未登録だった以下4件の記事を追加します。

## 追加した記事

| 公開日 | タイトル | URL |
| --- | --- | --- |
| 2026-01-09 | conftestによる自動レビュー | https://product.10x.co.jp/entry/2026/01/09/154331 |
| 2026-04-01 | GitHub Appの秘密鍵をGitHub Secretsから追い出す | https://product.10x.co.jp/entry/2026/04/01/163814 |
| 2026-04-07 | GitHubへのメンバー追加をConftestでバリデーションする | https://product.10x.co.jp/entry/2026/04/07/170704 |
| 2026-04-15 | PATも秘密鍵も管理せずにGoogle CloudからGitHub APIにアクセスする | https://product.10x.co.jp/entry/2026/04/15/163802 |

いずれも `sota1235` が著者である記事のみを追加しています。

## 確認方法

- 環境のネットワーク制限により `product.10x.co.jp` への直接アクセスができなかったため、Web 検索で著者を確認しました
- 既存ファイルとの重複がないことを `src/content/companyBlog/` 配下のファイル名・`link` で確認済み
- ファイル名規約は `fetch-media-data.ts` の自動生成パターン (`10x-YYYY-MM-DD-HHMMSS.json`) に合わせています
- JSON スキーマは `src/content.config.ts` の `companyBlog` 定義に準拠

## Test plan

- [ ] CI (Prettier / astro check / pa11y / Lighthouse) が通ること
- [ ] ローカルで `pnpm dev` を起動し、`/media` (もしくは会社ブログ一覧) で新規記事が表示されること


---
_Generated by [Claude Code](https://claude.ai/code/session_016FCaSreEWXzwws2ndxqSDY)_