### PR TITLE
add: 10X会社ブログ記事「GitHub Appの秘密鍵をGitHub Secretsから追い出す」を追加

### DIFF
--- a/src/content/companyBlog/10x-2026-04-01-remove-github-app-private-key-from-secrets.json
+++ b/src/content/companyBlog/10x-2026-04-01-remove-github-app-private-key-from-secrets.json
@@ -1,0 +1,6 @@
+{
+  "title": "GitHub Appの秘密鍵をGitHub Secretsから追い出す",
+  "company": "10X",
+  "link": "https://product.10x.co.jp/entry/2026/04/01/163814",
+  "pubDate": "2026-04-01"
+}


### PR DESCRIPTION
## Summary

- 10X Product Blog の sota1235 author archive (https://product.10x.co.jp/archive/author/sota1235) を確認し、未登録の記事を追加します
- 追加記事: [GitHub Appの秘密鍵をGitHub Secretsから追い出す](https://product.10x.co.jp/entry/2026/04/01/163814) (2026-04-01 公開)

## 備考

- 本セッションのリモート実行環境では `product.10x.co.jp` への直接アクセスがネットワークポリシーでブロックされていたため、Web検索の結果から sota1235 author の新規記事を特定しています
- 既存の最新エントリ (`10x-2026-03-06-155210.json`) 以降の sota1235 author 記事は上記1件のみです (2026-05/06 のものは検出されませんでした)

## Test plan

- [ ] `pnpm run astro check` でスキーマ違反がないこと
- [ ] `pnpm dev` で `/media` 等の一覧に新規エントリが反映されることを確認

https://claude.ai/code/session_01Aqhzudq8MJzJLsiqoF8WW5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aqhzudq8MJzJLsiqoF8WW5)_