### PR TITLE
fix(ci): fall back to direct merge when auto-merge cannot be enabled

### DIFF
--- a/.github/workflows/build-daily.yml
+++ b/.github/workflows/build-daily.yml
@@ -82,4 +82,8 @@ jobs:
             --base main \
             --head "$BRANCH_NAME"
           PR_NUMBER="$(gh pr list -R "$REPO" --base main --head "$BRANCH_NAME" --json number --jq '.[0].number')"
-          gh pr merge "$PR_NUMBER" -R "$REPO" --auto --merge
+          # Try to enable auto-merge first (waits for required checks). If the PR
+          # is already in a "clean" mergeable state, enablePullRequestAutoMerge
+          # fails ("Pull request is in clean status"), so fall back to a direct merge.
+          gh pr merge "$PR_NUMBER" -R "$REPO" --auto --merge \
+            || gh pr merge "$PR_NUMBER" -R "$REPO" --merge


### PR DESCRIPTION
The daily build workflow failed at `gh pr merge --auto` with
"Pull request is in clean status (enablePullRequestAutoMerge)".
enablePullRequestAutoMerge fails when the PR is already mergeable
(no pending required checks). Fall back to a direct merge in that case.

https://claude.ai/code/session_012qyagmftmMGnDHXwS5gkYz